### PR TITLE
fix(h700): fix Wi-Fi credential persistence across sleep and settings path divergence

### DIFF
--- a/skeleton/EXTRAS/Tools/h700/Settings.pak/launch.sh
+++ b/skeleton/EXTRAS/Tools/h700/Settings.pak/launch.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 SDCARD_PATH="/mnt/SDCARD"
-USERDATA_PATH="$SDCARD_PATH/.userdata"
-SHARED_USERDATA_PATH="$USERDATA_PATH/shared"
+USERDATA_PATH="$SDCARD_PATH/.userdata/h700"
+SHARED_USERDATA_PATH="$SDCARD_PATH/.userdata/shared"
 
 cd $(dirname "$0")
 ./settings.elf > settings.log 2>&1

--- a/skeleton/EXTRAS/Tools/h700/Settings.pak/launch.sh
+++ b/skeleton/EXTRAS/Tools/h700/Settings.pak/launch.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-SDCARD_PATH="/mnt/SDCARD"
-USERDATA_PATH="$SDCARD_PATH/.userdata/h700"
-SHARED_USERDATA_PATH="$SDCARD_PATH/.userdata/shared"
+SDCARD_PATH="${SDCARD_PATH:-/mnt/SDCARD}"
+USERDATA_PATH="${USERDATA_PATH:-$SDCARD_PATH/.userdata/h700}"
+SHARED_USERDATA_PATH="${SHARED_USERDATA_PATH:-$SDCARD_PATH/.userdata/shared}"
 
 cd $(dirname "$0")
 ./settings.elf > settings.log 2>&1

--- a/skeleton/SYSTEM/h700/etc/wifi/wifi_init.sh
+++ b/skeleton/SYSTEM/h700/etc/wifi/wifi_init.sh
@@ -11,7 +11,7 @@ WPA_ACTION_SCRIPT="$WIFI_RUNTIME_DIR/wpa_action.sh"
 
 write_default_config() {
 	mkdir -p "$WIFI_STATE_DIR" "$WIFI_SOCK_DIR"
-	if [ ! -f "$WPA_SUPPLICANT_CONF" ]; then
+	if [ ! -s "$WPA_SUPPLICANT_CONF" ] || ! grep -q "ctrl_interface=" "$WPA_SUPPLICANT_CONF" 2>/dev/null; then
 		cat > "$WPA_SUPPLICANT_CONF" << EOF
 ctrl_interface=$WIFI_SOCK_DIR
 disable_scan_offload=1
@@ -19,6 +19,8 @@ update_config=1
 wowlan_triggers=any
 
 EOF
+	elif ! grep -q "update_config=1" "$WPA_SUPPLICANT_CONF" 2>/dev/null; then
+		sed -i '1iupdate_config=1' "$WPA_SUPPLICANT_CONF" 2>/dev/null || echo "update_config=1" >> "$WPA_SUPPLICANT_CONF"
 	fi
 }
 
@@ -76,6 +78,7 @@ start() {
 
 	killall wpa_cli 2>/dev/null || true
 	killall wpa_supplicant 2>/dev/null || true
+	rm -f "$WIFI_SOCK_DIR/$WIFI_INTERFACE" 2>/dev/null || true
 	wpa_supplicant -B -i "$WIFI_INTERFACE" -c "$WPA_SUPPLICANT_CONF" -C "$WIFI_SOCK_DIR" >/dev/null 2>&1
 	wpa_cli -B -p "$WIFI_SOCK_DIR" -i "$WIFI_INTERFACE" -a "$WPA_ACTION_SCRIPT" >/dev/null 2>&1 || true
 	start_dhcp
@@ -86,6 +89,7 @@ stop() {
 	killall wpa_cli 2>/dev/null || true
 	systemctl stop wpa_supplicant "wpa_supplicant@$WIFI_INTERFACE.service" 2>/dev/null || true
 	killall wpa_supplicant 2>/dev/null || true
+	rm -f "$WIFI_SOCK_DIR/$WIFI_INTERFACE" 2>/dev/null || true
 	stop_dhcp
 	ip link set "$WIFI_INTERFACE" down 2>/dev/null || true
 	rfkill block wifi 2>/dev/null || true


### PR DESCRIPTION
## Summary

Resolves issues on the Anbernic H700 port where Wi-Fi passwords fail to persist across power/sleep cycles, empty configs prevent saving, and stale control sockets block network scanning on wake.

Detailed telemetry traces, reproduction steps, and root cause analysis are documented in [sjsamphex/nextui-h700-wifi-debug](https://github.com/sjsamphex/nextui-h700-wifi-debug/blob/main/ANALYSIS.md).

## Root Causes & Changes

### 1. Path Divergence in `Settings.pak/launch.sh`
- `MinUI.pak/launch.sh`, `/bin/suspend`, and `wifi_init.sh` default to `$SDCARD_PATH/.userdata/h700`.
- `Settings.pak/launch.sh` had hardcoded `USERDATA_PATH="$SDCARD_PATH/.userdata"` and `SHARED_USERDATA_PATH="$USERDATA_PATH/shared"`. Because this variable is exported to `settings.elf`, credentials entered in the UI were directed to `.userdata/wifi/wpa_supplicant.conf` instead of the system daemon path `.userdata/h700/wifi/wpa_supplicant.conf`.
- **Fix**: Aligned `USERDATA_PATH` to `${USERDATA_PATH:-$SDCARD_PATH/.userdata/h700}` and `SHARED_USERDATA_PATH` to `${SHARED_USERDATA_PATH:-$SDCARD_PATH/.userdata/shared}`. This respects inherited platform environment variables from `MinUI.pak` while providing safe fallbacks if launched standalone.

### 2. Config Self-Healing & `update_config=1` Enforcement
- If a FAT32 filesystem corruption or previous run created an empty or 0-byte `wpa_supplicant.conf`, `[ ! -f "$WPA_SUPPLICANT_CONF" ]` evaluated to false and never self-healed.
- Without `update_config=1`, `wpa_cli save_config` was rejected by `wpa_supplicant` with `FAIL` (`CTRL_IFACE: SAVE_CONFIG - Not allowed to update configuration (update_config=0)`).
- **Fix**: Updated `write_default_config()` in `wifi_init.sh` to check `[ ! -s ... ]` or missing `ctrl_interface=`, and automatically ensure `update_config=1` is present.

### 3. Stale Unix Domain Socket Clean-up
- When resuming from sleep or after sudden daemon terminations, `/tmp/wifi/sockets/wlan0` could remain in `/tmp`. A new `wpa_supplicant` instance would fail with:
  ```text
  ctrl_iface exists and seems to be in use - cannot override
  Failed to initialize control interface '/tmp/wifi/sockets'
  ```
  causing scans to fail completely.
- **Fix**: Purge stale socket `rm -f "$WIFI_SOCK_DIR/$WIFI_INTERFACE"` during both `start` and `stop` routines.

## Hardware Validation

Tested on physical **Anbernic RG SP** (`DEVICE=rgsp`, `PLATFORM=h700`) running **BaseOS 1.1.0** and **NextUI RC9**:
- **Cold boot**: Associated with Wi-Fi AP and obtained DHCP lease in 5s.
- **Deep sleep**: Clean daemon teardown and socket unbinding on lid close.
- **Wake from sleep**: Automatic reconnect and IP acquisition in 5s (clean PID allocation, no socket collisions).
- **Credential persistence**: Multiple network configurations entered via Settings successfully persisted across cold reboots.
