### PR TITLE
fix(h700): prevent RG SP speaker pops during audio transitions

### DIFF
--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -3172,6 +3172,9 @@ size_t SND_batchSamples_fixed_rate(const SND_Frame *frames, size_t frame_count)
 
 void SND_init(double sample_rate, double frame_rate)
 { // plat_sound_init
+#if defined(SND_TRANSITION_MUTE) && SND_TRANSITION_MUTE
+	SND_overrideMute(1);
+#endif
 	LOG_info("SND_init\n");
 	if(SDL_WasInit(SDL_INIT_AUDIO))
 		LOG_error("SND_init: already initialized\n");
@@ -3248,6 +3251,10 @@ void SND_init(double sample_rate, double frame_rate)
 
 void SND_quit(void)
 {
+#if defined(SND_TRANSITION_MUTE) && SND_TRANSITION_MUTE
+	// Gate the output before either pausing or closing the PCM.
+	SND_overrideMute(1);
+#endif
 	if (!snd.initialized)
 	{
 		LOG_warn("Skipping SND teardown, not initialized.\n");
@@ -3287,6 +3294,12 @@ void SND_pauseAudio(bool paused)
 	SDL_PauseAudioDevice(snd.device_id, paused);
 #else
 	SDL_PauseAudio(paused);
+#endif
+#if defined(SND_TRANSITION_MUTE) && SND_TRANSITION_MUTE
+	// Batch submission releases the gate only after buffering enough audio
+	// to start playback. Ordinary underrun pauses do not cycle the amplifier.
+	if (!paused)
+		SND_overrideMute(0);
 #endif
 }
 
@@ -4322,8 +4335,14 @@ void PWR_powerOff(int reboot)
 	}
 }
 
+#if defined(SND_TRANSITION_MUTE) && SND_TRANSITION_MUTE
+static int sleep_had_audio;
+#endif
 static void PWR_enterSleep(void)
 {
+#if defined(SND_TRANSITION_MUTE) && SND_TRANSITION_MUTE
+	sleep_had_audio = snd.initialized;
+#endif
 #if defined(SND_CLOSE_ON_SLEEP) && SND_CLOSE_ON_SLEEP
 	// On H700, fully close the audio device before sleeping: a PCM left open
 	// across suspend-to-RAM ends up in a state SDL takes ~10s to close on
@@ -4382,7 +4401,13 @@ static void PWR_exitSleep(void)
 	}
 	// reinitialize audio after sleep otherwise it doesnt come back on sometimes
 	LOG_info("Reinitialize audio after sleep\n");
+#if defined(SND_TRANSITION_MUTE) && SND_TRANSITION_MUTE
+	// A frontend that had no PCM must not acquire one just by waking up.
+	if (sleep_had_audio)
+		SND_resetAudio(snd.sample_rate_in, snd.frame_rate);
+#else
 	SND_resetAudio(snd.sample_rate_in, snd.frame_rate);
+#endif
 
 	sync();
 }

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -201,10 +201,16 @@ int main(int argc , char* argv[]) {
 	Config_readControls(); // restore controls (after the core has reported its defaults)
 
 	// Mute audio during startup to avoid pops (InitSettings would be logical, but too late)
+#if defined(SND_TRANSITION_MUTE) && SND_TRANSITION_MUTE
+	// H700 settings keep outputs gated until audio actually starts playing.
+	InitSettings();
+#endif
 	SND_overrideMute(1);
 	SND_init(core.sample_rate, core.fps);
 	SND_registerDeviceWatcher(Audio_onSinkChanged);
+#if !defined(SND_TRANSITION_MUTE) || !SND_TRANSITION_MUTE
 	InitSettings(); // after we initialize audio
+#endif
 	Menu_init();
 	Notification_init();
 	
@@ -325,6 +331,10 @@ int main(int argc , char* argv[]) {
 
 		hdmimon();
 	}
+#if defined(SND_TRANSITION_MUTE) && SND_TRANSITION_MUTE
+	// Disconnect the physical amplifier before exit graphics/core cleanup.
+	SND_overrideMute(1);
+#endif
 	int cw, ch;
 	unsigned char* pixels = GFX_GL_screenCapture(&cw, &ch);
 	
@@ -344,6 +354,12 @@ int main(int argc , char* argv[]) {
 	PLAT_clearTurbo();
 
 	Menu_quit();
+#if defined(SND_TRANSITION_MUTE) && SND_TRANSITION_MUTE
+	// Settings must still be mapped when the shared output gate is set.
+	SND_overrideMute(1);
+	if (GetAudioSink() == AUDIO_SINK_DEFAULT && !GetHDMI())
+		SND_quit();
+#endif
 	QuitSettings();
 
 finish:

--- a/workspace/h700/libmsettings/msettings.c
+++ b/workspace/h700/libmsettings/msettings.c
@@ -15,6 +15,7 @@
 #include "displaycal.h"
 #include "msettings.h"
 #include "sunxi_display2_min.h"
+#include "speaker_amp.h"
 
 ///////////////////////////////////////
 
@@ -28,7 +29,8 @@ typedef struct SettingsV1 {
 	int contrast;
 	int saturation;
 	int exposure;
-	int unused[2]; // for future use
+	int audio_muted; // runtime gate; uses a reserved slot, not a saved preference
+	int unused; // for future use
 	// NOTE: doesn't really need to be persisted but still needs to be shared
 	int jack;
 	int audiosink; // AUDIO_SINK_*
@@ -50,6 +52,7 @@ static Settings DefaultSettings = {
 	.contrast = SETTINGS_DEFAULT_CONTRAST,
 	.saturation = SETTINGS_DEFAULT_SATURATION,
 	.exposure = SETTINGS_DEFAULT_EXPOSURE,
+	.audio_muted = 1,
 	.jack = 0,
 	.audiosink = AUDIO_SINK_DEFAULT,
 	.displaycal_enabled = DISPLAYCAL_DEFAULT_ENABLED,
@@ -169,15 +172,17 @@ void InitSettings(void) {
 
 		memcpy(settings, &DefaultSettings, shm_size);
 		loadSettings();
+		// Playback never survives a session restart. Do not restore this gate
+		// from the settings file alongside the user's volume preference.
+		settings->audio_muted = 1;
 	}
 	// printf("brightness: %i\nspeaker: %i \n", settings->brightness, settings->speaker);
 	// Log mixer state before changing routing to help diagnose Bluetooth/USB DAC issues.
 	system("amixer");
 
-	// Make sure the H700 codec is routed to speaker/lineout before NextUI owns volume.
+	// Set DAC routing here; SetVolume owns the output switches. Enabling SPK
+	// here would briefly unmute a zero-volume device on every app transition.
 	if(GetAudioSink() == AUDIO_SINK_DEFAULT) {
-		system("amixer -q sset 'SPK' on >/dev/null 2>&1");
-		system("amixer -q sset 'LINEOUT' on >/dev/null 2>&1");
 		system("amixer -q sset 'OutputL Mixer DACL' on >/dev/null 2>&1");
 		system("amixer -q sset 'OutputR Mixer DACR' on >/dev/null 2>&1");
 	}
@@ -197,6 +202,7 @@ int InitializedSettings(void) {
 }
 void QuitSettings(void) {
 	munmap(settings, shm_size);
+	settings = NULL;
 	if (is_host) shm_unlink(SHM_KEY);
 }
 static inline void SaveSettings(void) {
@@ -339,6 +345,16 @@ void SetVolume(int value) // 0-20
 	else
 		settings->speaker = value;
 	SaveSettings();
+}
+void SetAudioMute(int muted) {
+	if (!settings) return;
+	muted = !!muted;
+	if (settings->audio_muted == muted) return;
+	settings->audio_muted = muted;
+	// Keep the transition gate shared with keymon without changing the
+	// saved volume or touching Bluetooth/USB/HDMI volume controls.
+	if (GetAudioSink() == AUDIO_SINK_DEFAULT && !GetHDMI())
+		SetRawVolume(scaleVolume(GetVolume()));
 }
 // TODO: wire up headphone-jack detection in H700 keymon.
 void SetJack(int value) {
@@ -878,6 +894,10 @@ void SetRawVolume(int val) { // in: 0-100
 	}
 	else {
 		// Speaker path: grab the card that is called "audiocodec"
+		int physical_amp = speakerAmpSupported();
+		int muted = val == 0 || settings->audio_muted;
+		if (physical_amp && muted && speakerAmpSet(0) < 0)
+			fprintf(stderr, "Failed to disable RG SP physical amplifier\n");
 		int card_num = get_audiocodec_card_num();
 		if(card_num < 0) {
 			card_num = 0; // fallback to card 0 if we can't find it
@@ -889,10 +909,24 @@ void SetRawVolume(int val) { // in: 0-100
             return;
         }
 
+        // TinyALSA takes raw control names, not amixer's simple-control names.
+        // Disable the speaker before changing the line output or its gain.
+        struct mixer_ctl *spk = mixer_get_ctl_by_name(mixer, "SPK Switch");
+        struct mixer_ctl *lineout_switch = mixer_get_ctl_by_name(mixer, "LINEOUT Switch");
+        if (muted && !physical_amp) {
+            if (spk && mixer_ctl_set_value(spk, 0, 0) < 0)
+                fprintf(stderr, "Failed to mute SPK Switch\n");
+            if (lineout_switch && mixer_ctl_set_value(lineout_switch, 0, 0) < 0)
+                fprintf(stderr, "Failed to mute LINEOUT Switch\n");
+        }
+
         struct mixer_ctl *digital = mixer_get_ctl_by_name(mixer, "digital volume");
-        if (digital) {
-			mixer_ctl_set_percent(digital, 0, 100 - val); // reversed mapping
-			//printf("Set 'digital volume' to %d%%\n", val); fflush(stdout);
+        if (digital && mixer_ctl_get_value(digital, 0) != 63) {
+			// Stock's PCM hook holds this at 63 (100%); the lineout control
+			// owns volume. Once the hook is removed, the old inverted mapping
+			// attenuates playback as the user raises the volume.
+			if (mixer_ctl_set_percent(digital, 0, 100) < 0)
+				fprintf(stderr, "Failed to set digital volume\n");
 		}
 
 		struct mixer_ctl *lineout = mixer_get_ctl_by_name(mixer, "lineout volume");
@@ -901,13 +935,16 @@ void SetRawVolume(int val) { // in: 0-100
 			//printf("Set 'lineout volume' to %d%%\n", val); fflush(stdout);
 		}
 
-		struct mixer_ctl *spk = mixer_get_ctl_by_name(mixer, "SPK");
-		if (spk)
-			mixer_ctl_set_value(spk, 0, val == 0 ? 0 : 1);
+        // Restore the line output before the speaker, once gain is configured.
+        if (!muted && !physical_amp) {
+            if (lineout_switch && mixer_ctl_set_value(lineout_switch, 0, 1) < 0)
+                fprintf(stderr, "Failed to enable LINEOUT Switch\n");
+            if (spk && mixer_ctl_set_value(spk, 0, 1) < 0)
+                fprintf(stderr, "Failed to enable SPK Switch\n");
+        }
 
-		struct mixer_ctl *lineout_switch = mixer_get_ctl_by_name(mixer, "LINEOUT");
-		if (lineout_switch)
-			mixer_ctl_set_value(lineout_switch, 0, val == 0 ? 0 : 1);
+        if (!muted && physical_amp && speakerAmpSet(1) < 0)
+            fprintf(stderr, "Failed to enable RG SP physical amplifier\n");
 
 		mixer_close(mixer);
 	}

--- a/workspace/h700/libmsettings/msettings.h
+++ b/workspace/h700/libmsettings/msettings.h
@@ -45,6 +45,7 @@ void SetDisplayCalRedGain(int value); // 0-200, 100 is neutral
 void SetDisplayCalGreenGain(int value); // 0-200, 100 is neutral
 void SetDisplayCalBlueGain(int value); // 0-200, 100 is neutral
 void SetVolume(int value); // 0-20
+void SetAudioMute(int muted); // transient shared output gate; preserves user volume
 
 int GetJack(void);
 void SetJack(int value); // 0-1

--- a/workspace/h700/libmsettings/speaker_amp.h
+++ b/workspace/h700/libmsettings/speaker_amp.h
@@ -1,0 +1,78 @@
+/* RG SP vendor-kernel workaround. Its sunxi_spk_event is a no-op.
+ * Only touch the verified active-high PI5 amplifier pin; other hardware keeps
+ * the normal mixer path. No pin mux, pull, drive, or regulator changes.
+ */
+#include <time.h>
+
+#ifndef SPEAKER_AMP_DT
+#define SPEAKER_AMP_DT "/sys/firmware/devicetree/base/soc@03000000/codec@0x05096000/"
+#endif
+#ifndef SPEAKER_AMP_GPIO
+#define SPEAKER_AMP_GPIO "/sys/kernel/debug/gpio"
+#endif
+#ifndef SPEAKER_AMP_DATA
+#define SPEAKER_AMP_DATA "/sys/kernel/debug/sunxi_pinctrl/data"
+#endif
+
+static int speakerAmpProperty(const char *name, unsigned char *data, size_t size) {
+    char path[256];
+    snprintf(path, sizeof(path), "%s%s", SPEAKER_AMP_DT, name);
+    FILE *f = fopen(path, "rb");
+    if (!f) return 0;
+    int ok = fread(data, 1, size, f) == size && fgetc(f) == EOF;
+    fclose(f);
+    return ok;
+}
+
+static int speakerAmpSupported(void) {
+    const char *device = getenv("DEVICE");
+    unsigned char pin[28], level[4], count[4];
+    static const unsigned char expected_pin[] = {
+        0,0,0,8, 0,0,0,5, 0,0,0,1
+    };
+    static const unsigned char one[] = {0,0,0,1};
+    return device && !strcmp(device, "rgsp") &&
+        speakerAmpProperty("pa-pin-0", pin, sizeof(pin)) &&
+        !memcmp(pin + 4, expected_pin, sizeof(expected_pin)) &&
+        speakerAmpProperty("pa-pin-level-0", level, sizeof(level)) &&
+        !memcmp(level, one, sizeof(one)) &&
+        speakerAmpProperty("pa-pin-max", count, sizeof(count)) &&
+        !memcmp(count, one, sizeof(one));
+}
+
+static int speakerAmpState(void) {
+    FILE *f = fopen(SPEAKER_AMP_GPIO, "r");
+    if (!f) return -1;
+    char line[256];
+    int result = -1;
+    while (fgets(line, sizeof(line), f)) {
+        unsigned int gpio;
+        if (sscanf(line, " gpio-%u", &gpio) == 1 && gpio == 261) {
+            if (strstr(line, "out hi")) result = 1;
+            else if (strstr(line, "out lo")) result = 0;
+            break;
+        }
+    }
+    fclose(f);
+    return result;
+}
+
+static int speakerAmpSet(int enabled) {
+    int previous = speakerAmpState();
+    if (previous < 0) return -1;
+    if (previous == enabled) return 0;
+    /* Let the codec settle before connecting the amplifier. */
+    if (enabled) usleep(100000);
+    FILE *f = fopen(SPEAKER_AMP_DATA, "w");
+    if (!f) return -1;
+    int ok = fprintf(f, "PI5 %d\n", !!enabled) > 0;
+    if (fclose(f)) ok = 0;
+    if (!ok || speakerAmpState() != enabled) return -1;
+    /* Let amplifier shutdown settle before changing the analog output. */
+    if (!enabled) usleep(100000);
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    fprintf(stderr, "AUDIO_AMP %ld.%06ld pid=%d enabled=%d\n",
+            (long)ts.tv_sec, ts.tv_nsec / 1000, getpid(), enabled);
+    return 0;
+}

--- a/workspace/h700/platform/platform.c
+++ b/workspace/h700/platform/platform.c
@@ -832,7 +832,7 @@ int PLAT_pickSampleRate(int requested, int max) {
 }
 
 void PLAT_overrideMute(int mute) {
-	system(mute ? "amixer -q sset 'SPK' off" : "amixer -q sset 'SPK' on");
+	SetAudioMute(mute);
 }
 
 char* PLAT_getModel(void) {

--- a/workspace/h700/platform/platform.h
+++ b/workspace/h700/platform/platform.h
@@ -180,6 +180,7 @@ extern int needs_portrait_sdl; // DEVICE=rg28xx: SDL rotates onto the portrait p
 
 #define SDCARD_PATH "/mnt/SDCARD"
 #define MUTE_VOLUME_RAW 0
+#define SND_TRANSITION_MUTE 1
 
 // Stock H700 audio must be closed before suspend to avoid a long stall on wake.
 #define SND_CLOSE_ON_SLEEP 1


### PR DESCRIPTION
Addresses [#25](https://github.com/pvaibhav/NextUI/issues/25) on the Anbernic RG SP. Game startup, game exit, and sleep/wake are silent in the tested scenarios, while normal playback and volume adjustment continue to work.

## Problem

On the tested BaseOS device, the vendor kernel's `sunxi_spk_event` callback simply returns success without controlling the speaker amplifier. Disassembly of the device's kernel confirmed this, and GPIO readback showed the amplifier still enabled when the SPK DAPM widget was off. Consequently, muting the SPK mixer control did not reliably isolate the speaker from codec transitions; game exit could pop even at volume zero.

A diagnostic using the original emulator and library held the device-tree-defined amplifier enable pin, PI5, low. This silenced playback and both startup and exit pops.

## Changes

- Add an RG SP amplifier-control workaround, guarded by `DEVICE=rgsp` and matching device-tree pin, output function, polarity, and pin-count properties. It uses the vendor debugfs data interface and checks the resulting GPIO state.
- Disable the amplifier before audio initialization, exit cleanup, and PCM teardown. Enable it after buffered playback starts, with settling delays around amplifier transitions.
- Share the transient mute state between settings clients without changing the saved volume or the settings structure size. Frontend initialization no longer unconditionally enables the speaker outputs.
- Keep the original ALSA routing configuration on the verified RG SP path. Hold digital gain at the vendor's value of 63 and apply user volume through the lineout gain.
- Close the built-in PCM on normal emulator exit, retaining the Bluetooth/external-output exclusions. Preserve the existing close-before-suspend behavior and avoid creating audio on wake when it was not previously initialized.

## Alternative considered

[Turro75's audio-server solution](https://github.com/pvaibhav/NextUI/issues/25#issuecomment-5345251058) addresses the same transition noise by keeping ALSA open across application launches and exits. An OSS/DSP preload wrapper redirects application audio into a FIFO, and a persistent server writes it to ALSA. This is compatible with our finding: avoiding codec transitions and disabling the amplifier during those transitions are two ways to keep the transient from reaching the speaker.

The trade-offs are:

- **Audio server:** can cover other SDL binaries through their launch environment, provided SDL includes the OSS/DSP backend, and does not require the RG SP amplifier pin workaround. It adds a server, FIFO, preload wrapper, and lifecycle integration. The [implementation reviewed](https://github.com/Turro75/MyMinUI/tree/72ed4f3dd80d96646c11bf9363242565320d9566/workspace/h700/audioserver) uses fixed 48 kHz stereo S16 audio and its own buffering and pacing. Its output routing, suspend behavior, and recovery would need integration and validation with NextUI.
- **This change:** preserves the existing ALSA playback path and format negotiation, while allowing PCM to close on exit and before suspend. It adds no persistent audio service, but relies on a vendor debugfs interface and verified RG SP pin configuration, adds 100 ms settling waits when changing amplifier state, and does not automatically cover other binaries that bypass these mute calls.

The amplifier approach was chosen because physical pin testing directly confirmed that it suppresses the pops on the affected device, and it fits NextUI's existing audio lifecycle, including close-before-suspend. It has passed the hardware checks below. The audio-server alternative has not been tested on this device during this investigation; no comparative latency, power, or audio-quality claim is made. Repairing the kernel amplifier callback remains the cleaner long-term solution.

## Validation

Tested on an Anbernic RG SP running BaseOS 1.1.0, vendor kernel 4.9.170, and NextUI 6.14.0-rc9-based binaries.

- Normal playback and volume adjustment worked, with no startup or exit pop.
- Zero-volume launch and exit produced no pops; GPIO readback confirmed the amplifier stayed disabled throughout.
- Game sleep/wake restored audio normally, with no pops during sleep, wake, or subsequent exit. Sleep/wake from the rebuilt frontend also passed.
- A fresh boot confirmed the frontend and volume daemon loaded the replacement library. No `.asoundrc` override was used.
- A bounded GPIO/PCM trace confirmed the amplifier enabled after PCM playback began and disabled before PCM close. In the normal exit test, amplifier disable preceded PCM close by approximately 367 ms.
- Upstream GCC 8.3 builds, in-memory volume checks, amplifier identity/readback checks, and `git diff --check` passed. The diagnostic harnesses and captures are local investigation artifacts and are not included in this branch.

## Limitations

This is a userspace workaround for the tested vendor kernel and depends on its debugfs GPIO interface. Repairing the kernel speaker-event callback would provide a cleaner long-term solution.

Hardware validation covers one RG SP and one game/core. Headphones, Bluetooth, HDMI, USB DACs, and other H700 models have not been tested. Although direct PI5 control is restricted to the verified RG SP configuration, the branch also changes shared H700 mute and mixer behavior.

The settings library, emulator, frontend, and volume daemon were built using the project makefiles and upstream GCC 8.3 image `ghcr.io/loveretro/h700-toolchain@sha256:47148fa93d6c3196956aef4f418cb5a2d4f373ce0881e7e8d92c51ac5ef60afc`, with the project’s optimization and LTO settings. All four resulting binaries were installed for the hardware test. Existing device runtime libraries and the tested dependency source revisions were retained.
